### PR TITLE
查询快递100：手机号bug

### DIFF
--- a/src/Express100.php
+++ b/src/Express100.php
@@ -76,8 +76,8 @@ class Express100
             'num' => $tracking_code,
         ];
 
-        if (!empty($mobile)) {
-            $data['mobiletelephone'] = $phone;
+        if (!empty($phone)) {
+            $data['phone'] = $phone;
         }
 
         $post['param'] = json_encode($data);


### PR DESCRIPTION
快递100文档：
```
phone | string | 否 | 13888888888 | 收、寄件人的电话号码（手机和固定电话均可，只能填写一个，顺丰速运和丰网速运必填，其他快递公司选填。如座机号码有分机号，分机号无需传入。）
```
代码中手机号这块有错误，所以提交个修复